### PR TITLE
perf: orjson, check local cache for get_exists

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ where = ["src"]
 
 [project]
 name = "aws-utils"
-version = "1.1.2"
+version = "1.1.3"
 description = "A collection of utilities for working with the AWS boto3 client"
 classifiers=[
     "Development Status :: 5 - Production/Stable",
@@ -23,6 +23,7 @@ dependencies = [
 [project.optional-dependencies]
 npy = [
   "numpy",
+  "orjson"
 ]
 aio = [
   "aioboto3",

--- a/src/aws_utils/aio_npy_storage.py
+++ b/src/aws_utils/aio_npy_storage.py
@@ -1,7 +1,7 @@
 import logging
 import aioboto3
 import aiofiles
-import json
+import orjson
 import numpy as np
 from botocore.exceptions import ClientError
 from pathlib import Path
@@ -60,7 +60,7 @@ class AIONpyReader:
 
         async with aiofiles.open(metadata_path) as f:
             content = await f.read()
-            self._metadata_cache = json.loads(content)
+            self._metadata_cache = orjson.loads(content)
 
         for shard in self._metadata_cache["shards"]:
             shard_key = self._get_shard_key(shard["filename"])
@@ -80,6 +80,12 @@ class AIONpyReader:
         logger.info(
             f"Checking if embeddings exist in S3 at s3://{self.bucket}/{self._metadata_key}"
         )
+        if (
+            self._cache_locally
+            and (self._local_cache_dir / self._metadata_key).exists()
+        ):
+            return True
+
         try:
             async with await self._get_client() as client:
                 await client.head_object(Bucket=self.bucket, Key=self._metadata_key)
@@ -95,15 +101,13 @@ class AIONpyReader:
                     self._local_cache_dir / self._metadata_key
                 ) as f:
                     content = await f.read()
-                    self._metadata_cache = json.loads(content)
+                    self._metadata_cache = orjson.loads(content)
             else:
                 async with await self._get_client() as client:
                     response = await client.get_object(
                         Bucket=self.bucket, Key=self._metadata_key
                     )
-                    self._metadata_cache = json.loads(
-                        (await response["Body"].read()).decode("utf-8")
-                    )
+                    self._metadata_cache = orjson.loads((await response["Body"].read()))
         return self._metadata_cache
 
     async def _range_read(

--- a/tests/test_aio_npy_storage.py
+++ b/tests/test_aio_npy_storage.py
@@ -72,7 +72,7 @@ class TestAIONpyReader:
         )
         yield
 
-    async def test_check_exists(self, s3, test_bucket):
+    async def test_check_exists(self, s3, tmp_path, test_bucket):
         mock_client = MockAsyncS3Client(s3)
         assert await self.reader.check_exists() is True
 
@@ -80,6 +80,18 @@ class TestAIONpyReader:
             bucket=test_bucket, key_prefix="nonexistent", client=mock_client
         )
         assert await non_existent_reader.check_exists() is False
+
+        cached_reader = AIONpyReader(
+            bucket=test_bucket,
+            key_prefix="something_completely_different",
+            client=mock_client,
+            cache_dir=str(tmp_path),
+        )
+        meta_path = tmp_path / cached_reader._metadata_key
+        meta_path.parent.mkdir(parents=True, exist_ok=True)
+        meta_path.write_bytes(b"{}")  # minimal valid JSON
+
+        assert await cached_reader.check_exists() is True
 
     async def test_get_sample_count(self):
         count = await self.reader.get_sample_count()


### PR DESCRIPTION
Lookin' after the milliseconds:

- Use `orjson` for json deserialization (metadata json can be >30MB), also avoids need to convert bytes -> string
- Check local cache first for `get_exists` rather than always hitting S3