### PR TITLE
feat: add get s3 bucket region utility

### DIFF
--- a/src/aws_utils/s3.py
+++ b/src/aws_utils/s3.py
@@ -17,6 +17,19 @@ class S3UrlParts(NamedTuple):
     key: str
 
 
+def get_bucket_region(bucket_name: str, client=None) -> str | None:
+    """
+    Dynamically find the region for a given S3 bucket.
+    """
+    s3_client = client or _get_client()
+    response = s3_client.head_bucket(Bucket=bucket_name)
+    return (
+        response.get("ResponseMetadata", {})
+        .get("HTTPHeaders", {})
+        .get("x-amz-bucket-region", None)
+    )
+
+
 def parse_s3_url(url: str) -> S3UrlParts:
     """
     Parses an s3 URL with either an s3:// or https:// scheme, to extract the bucket and key.
@@ -157,5 +170,6 @@ def upload_dir(source_path: str, bucket: str, prefix: str, client=None):
             relative_path = os.path.relpath(local_path, source_path)
             s3_path = os.path.join(prefix, relative_path)
             manager.upload(local_path, bucket, s3_path)
+
     # Wait for all uploads to complete
     manager.shutdown()

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -192,3 +192,23 @@ class TestUploadDir:
             ]
         )
         mock_manager.shutdown.assert_called_once()
+
+
+class TestGetBucketRegion:
+    @pytest.mark.parametrize(
+        ("headers", "expected"),
+        [
+            ({"x-amz-bucket-region": "us-east-1"}, "us-east-1"),
+            ({"x-amz-bucket-region": "eu-central-1"}, "eu-central-1"),
+            ({}, None),
+        ],
+    )
+    def test_func(self, headers, expected):
+        mock_client = mock.MagicMock()
+        mock_client.head_bucket.return_value = {
+            "ResponseMetadata": {"HTTPHeaders": headers}
+        }
+
+        result = s3.get_bucket_region(bucket_name="my-bucket", client=mock_client)
+        assert result == expected
+        mock_client.head_bucket.assert_called_once_with(Bucket="my-bucket")


### PR DESCRIPTION
- Add `s3.get_bucket_region` utility which, given a bucket name, returns the name of the region the bucket is in
- Useful downstream for cross-platform bucket access, since clients often need to specify the region in advance of other operations (e.g. to get signed URLs)