### PR TITLE
fix: normalise urls for bucket-agnosticism

### DIFF
--- a/src/aws_utils/aio_npy_storage.py
+++ b/src/aws_utils/aio_npy_storage.py
@@ -7,7 +7,7 @@ from botocore.exceptions import ClientError
 from pathlib import Path
 from typing import Any, AsyncGenerator
 
-from .npy_storage import METADATA_KEY
+from .npy_storage import METADATA_KEY, _normalize_url
 
 
 logger = logging.getLogger(__name__)
@@ -205,19 +205,21 @@ class AIONpyReader:
         shards = metadata["shards"]
         embedding_dim = metadata["embedding_dim"]
 
-        # Create a mapping from URL to (shard_index, url_index)
+        # Build lookup with normalized keys so that full s3://bucket/key URLs and
+        # bare key paths both resolve to the same entry regardless of how the NPY
+        # metadata was written.
         url_to_location = {}
         for shard_idx, shard in enumerate(shards):
             for url_idx, url in enumerate(shard["urls"]):
-                url_to_location[url] = (shard_idx, url_idx)
+                url_to_location[_normalize_url(url)] = (shard_idx, url_idx)
 
         # Prepare results in the same order as input
         embeddings_list = []
         found_urls = []
 
         for url in urls:
-            if url in url_to_location:
-                shard_idx, url_idx = url_to_location[url]
+            if _normalize_url(url) in url_to_location:
+                shard_idx, url_idx = url_to_location[_normalize_url(url)]
                 shard = shards[shard_idx]
                 embedding = await self._read_shard_chunk(shard, url_idx, url_idx + 1)
                 embeddings_list.append(embedding)

--- a/src/aws_utils/npy_storage.py
+++ b/src/aws_utils/npy_storage.py
@@ -43,6 +43,13 @@ logger = logging.getLogger(__name__)
 METADATA_KEY = "embeddings_metadata.json"
 
 
+def _normalize_url(url: str) -> str:
+    """Strip s3://bucket/ prefix if present so key-only and full-URL forms match."""
+    if url.startswith("s3://"):
+        return url.split("/", 3)[-1]
+    return url
+
+
 class NpyWriter:
     """
     S3-compatible numpy array writer.
@@ -324,19 +331,21 @@ class NpyReader:
         shards = metadata["shards"]
         embedding_dim = metadata["embedding_dim"]
 
-        # Create a mapping from URL to (shard_index, url_index)
+        # Build lookup with normalized keys so that full s3://bucket/key URLs and
+        # bare key paths both resolve to the same entry regardless of how the NPY
+        # metadata was written.
         url_to_location = {}
         for shard_idx, shard in enumerate(shards):
             for url_idx, url in enumerate(shard["urls"]):
-                url_to_location[url] = (shard_idx, url_idx)
+                url_to_location[_normalize_url(url)] = (shard_idx, url_idx)
 
         # Prepare results in the same order as input
         embeddings_list = []
         found_urls = []
 
         for url in urls:
-            if url in url_to_location:
-                shard_idx, url_idx = url_to_location[url]
+            if _normalize_url(url) in url_to_location:
+                shard_idx, url_idx = url_to_location[_normalize_url(url)]
                 shard = shards[shard_idx]
                 embedding = self._read_shard_chunk(shard, url_idx, url_idx + 1)
                 embeddings_list.append(embedding)


### PR DESCRIPTION
- After making the embedding storage bucket agnostic (we just store the keys, not bucket) as part of the Cross Region Sanity Sapper project, penguins has broken
- Fix penguins by normalising urls in the read path(s) it uses

<img width="1402" height="1122" alt="image" src="https://github.com/user-attachments/assets/b202c689-2851-47f2-b136-696aaf970d2f" />
